### PR TITLE
Get searches to work with accented characters

### DIFF
--- a/googlesearch/googlesearch.py
+++ b/googlesearch/googlesearch.py
@@ -32,7 +32,7 @@ class GoogleSearch:
             start = i * GoogleSearch.RESULTS_PER_PAGE
             opener = urllib2.build_opener()
             opener.addheaders = GoogleSearch.DEFAULT_HEADERS
-            response = opener.open(GoogleSearch.SEARCH_URL + "?q="+ urllib2.quote(query) + ("" if start == 0 else ("&start=" + str(start))))
+            response = opener.open(GoogleSearch.SEARCH_URL + "?q="+ urllib2.quote(query.encode('utf-8')) + ("" if start == 0 else ("&start=" + str(start))))
             soup = BeautifulSoup(response.read(), "lxml")
             response.close()
             if total is None:


### PR DESCRIPTION
This change got my local version to work with accented characters with data like:
response = GoogleSearch().search('Köbenhavn')

, which ends up to:
  File "C:\softat\Python27\lib\site-packages\googlesearch\googlesearch.py", line 35, in search
    response = opener.open(GoogleSearch.SEARCH_URL + "?q="+ urllib2.quote(query) + "&hl=" + language + ("" if start == 0 else ("&start=" + str(start))))
  File "C:\softat\Python27\lib\urllib.py", line 1298, in quote
    return ''.join(map(quoter, s))
KeyError: u'\xf6'